### PR TITLE
Fix Node.js Oauth2 client dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# NPM Dependency directory
+node_modules
+
+# Developement related files
+.DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # SmartThings
 Various odds and ends interesting for SmartThings
 
-* stoauth.js - example node.js oauth client for authenticating with a SmartApp REST endpoint
+## Installation
+npm install
+
+## Running
+
+  `npm stoauth.js <CLIENT_ID> <CLIENT_SECRET>`
+
+  stoauth.js - example node.js oauth client for authenticating with a SmartApp REST endpoint

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "SmartThings",
+  "description": "Gets TokenId",
+  "main": "stoauth.js",
+  "dependencies": {
+    "express": "4.12.2",
+    "request": "2.55.0",
+    "JSON": "1.0.0",
+    "simple-oauth2" : "^0.6.0"
+  }
+}

--- a/stoauth.js
+++ b/stoauth.js
@@ -5,6 +5,7 @@
  npm install express
  npm install request
  npm install JSON
+ npm install simple-oauth2
 */
 
 


### PR DESCRIPTION
hi there, 

you left out `simple-oauth2`

I work at SmartThings and I found your Node.js oauth-token getter super helpful. Here's just some improvements. 

`npm install` to install all Node.js dependency. 
